### PR TITLE
Make it compatible with Node.js 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,38 +1,55 @@
-const ts = require('typescript');
-const { version, name } = require('./package.json');
-const { join, dirname } = require('path');
-const { access, constants, readFileSync } = require('fs');
+'use strict';
 
-const debug = require('debug')(name);
+var _debug;
 
-debug('versions', {
-    [name]: version,
-    typescript: ts.version,
-});
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
-const cache = {};
+var ts = require('typescript');
+
+var _require = require('./package.json'),
+    version = _require.version,
+    name = _require.name;
+
+var _require2 = require('path'),
+    join = _require2.join,
+    dirname = _require2.dirname;
+
+var _require3 = require('fs'),
+    access = _require3.access,
+    constants = _require3.constants,
+    readFileSync = _require3.readFileSync;
+
+var debug = require('debug')(name);
+
+debug('versions', (_debug = {}, _defineProperty(_debug, name, version), _defineProperty(_debug, 'typescript', ts.version), _debug));
+
+var cache = {};
 
 function tsify(content, fileName) {
-    const searchPath = ts.normalizePath(ts.sys.getCurrentDirectory());
-    const configFileName = process.env.TSCONFIG || ts.findConfigFile(searchPath, ts.sys.fileExists);
+    var searchPath = ts.normalizePath(ts.sys.getCurrentDirectory());
+    var configFileName = process.env.TSCONFIG || ts.findConfigFile(searchPath, ts.sys.fileExists);
 
-    const compilerOptions = getCompilerOptionsViaCache(configFileName);
+    var compilerOptions = getCompilerOptionsViaCache(configFileName);
     compilerOptions.sourceMap = false;
     compilerOptions.inlineSourceMap = true;
 
-    debug('transpileModule', { fileName });
-    const { outputText, diagnostics } = ts.transpileModule(content, {
-        fileName,
-        compilerOptions,
-        reportDiagnostics: true,
-    });
-    debug({ diagnostics });
+    debug('transpileModule', { fileName: fileName });
+
+    var _ts$transpileModule = ts.transpileModule(content, {
+        fileName: fileName,
+        compilerOptions: compilerOptions,
+        reportDiagnostics: true
+    }),
+        outputText = _ts$transpileModule.outputText,
+        diagnostics = _ts$transpileModule.diagnostics;
+
+    debug({ diagnostics: diagnostics });
 
     return outputText;
 }
 
 function getCompilerOptionsViaCache(configFileName) {
-    let options;
+    var options = void 0;
 
     if (!(options = cache[configFileName])) {
         options = cache[configFileName] = getCompilerOptions(configFileName);
@@ -42,25 +59,25 @@ function getCompilerOptionsViaCache(configFileName) {
 }
 
 function getCompilerOptions(configFileName) {
-    const { config, error } = ts.readConfigFile(configFileName, ts.sys.readFile);
+    var _ts$readConfigFile = ts.readConfigFile(configFileName, ts.sys.readFile),
+        config = _ts$readConfigFile.config,
+        error = _ts$readConfigFile.error;
+
     if (error) {
-        throw new Error(`TS config error in ${configFileName}: ${error.messageText}`);
+        throw new Error('TS config error in ' + configFileName + ': ' + error.messageText);
     }
 
-    const { options } = ts.parseJsonConfigFileContent(
-        config,
-        ts.sys,
-        ts.getDirectoryPath(configFileName),
-        {},
-        configFileName);
-    debug('getCompilerOptions', { configFileName, options });
+    var _ts$parseJsonConfigFi = ts.parseJsonConfigFileContent(config, ts.sys, ts.getDirectoryPath(configFileName), {}, configFileName),
+        options = _ts$parseJsonConfigFi.options;
+
+    debug('getCompilerOptions', { configFileName: configFileName, options: options });
     return options;
 }
 
 module.exports = [{
     ext: '.ts',
-    transform: tsify,
+    transform: tsify
 }, {
     ext: '.tsx',
-    transform: tsify,
+    transform: tsify
 }];


### PR DESCRIPTION
Object destructuring assignment like "const { version, name } = require('./package.json');" is not supported in Node.js 4 so this change makes it compatible with older Node.